### PR TITLE
Add minimal StatPro Android skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
-# Statpro
-My
+# StatPro
+
+StatPro is an Android application that showcases a collection of sports analysis tools. The project contains a simple example `MainActivity` listing all available analyses and alerts. Each feature is displayed on screen for demonstration purposes.
+
+This repository provides a minimal Android Gradle setup and is not intended for production use. You can import it into Android Studio to explore the structure and extend the implementation.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,0 +1,29 @@
+plugins {
+    id 'com.android.application'
+    id 'kotlin-android'
+}
+
+android {
+    namespace 'com.statpro'
+    compileSdk 34
+
+    defaultConfig {
+        applicationId 'com.statpro'
+        minSdk 24
+        targetSdk 34
+        versionCode 1
+        versionName '1.0'
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.core:core-ktx:1.12.0'
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,15 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.statpro">
+
+    <application
+        android:allowBackup="true"
+        android:label="StatPro"
+        android:theme="@style/Theme.AppCompat.Light.NoActionBar">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/app/src/main/java/com/statpro/MainActivity.kt
+++ b/app/src/main/java/com/statpro/MainActivity.kt
@@ -1,0 +1,86 @@
+package com.statpro
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import android.widget.TextView
+
+class MainActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+        val textView: TextView = findViewById(R.id.textview)
+        textView.text = FeatureList.features.joinToString(separator = "\n") { "\u2022 $it" }
+    }
+}
+
+object FeatureList {
+    val features = listOf(
+        // Análise Estatística
+        "Análise de Over/Under",
+        "Análise de Ambas Marcam (BTTS)",
+        "Análise de Handicap Asiático",
+        "Probabilidade de Vitória por Time (1X2)",
+        "Média de Gols por Partida",
+        "Média de Escanteios",
+        "Média de Cartões",
+        "Análise de Primeiros e Segundos Tempos (HT/FT)",
+        "Análise de Tendências de Resultado",
+        "Percentual de Clean Sheets",
+
+        // Momentos de Partida
+        "Gol nos primeiros minutos",
+        "Gol antes do intervalo",
+        "Gol no fim do jogo",
+        "Períodos com mais gols",
+        "Tendência de gols nos últimos 10 minutos",
+        "Times que fazem ou sofrem gols no final",
+
+        // Volume de Mercado
+        "Volume de Apostas por Resultado (1X2)",
+        "Volume de Dinheiro Movimentado",
+        "Variação do Volume ao longo das últimas horas",
+        "Porcentagem de Apostas por Mercado",
+        "Análise de Variação das Odds",
+
+        // IA e Machine Learning
+        "Previsão de Resultado com base em estatísticas",
+        "Probabilidade de Gol ao Vivo",
+        "Score Expected (XG)",
+        "Score Simulado",
+        "Probabilidade de Over/Under por IA",
+        "Sinal de Valor",
+        "Detecção de Odds Desajustadas",
+
+        // Alertas Inteligentes
+        "Alerta de Over Limit",
+        "Alerta de Virada Improvável",
+        "Alerta de Anomalias de Mercado",
+        "Alerta de Padrão de Gols",
+
+        // Performance Recente
+        "Últimos 5 jogos (Home/Away)",
+        "Sequência de Vitórias/Derrotas",
+        "Performance como mandante/visitante",
+        "Aproveitamento contra times do mesmo nível",
+
+        // Confronto Direto
+        "Resultados dos últimos confrontos",
+        "Média de gols em confrontos diretos",
+        "Tendência de ambas marcam em confrontos diretos",
+
+        // Fatores Externos
+        "Condição do Gramado",
+        "Clima (Chuva, calor, etc)",
+        "Público e Estádio",
+        "Desfalques Importantes",
+
+        // Estratégias Sugeridas
+        "Sinal para Over 2.5",
+        "Sinal para Ambas Marcam",
+        "Sinal para Handicap",
+        "Sinal para Vitória Limpa",
+        "Sugestão de Entrada ao Vivo",
+        "Sugestão de Cash Out",
+        "Sugestão de Esperar"
+    )
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <TextView
+            android:id="@+id/textview"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textSize="16sp" />
+    </ScrollView>
+</LinearLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,16 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.1.2'
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = 'StatPro'
+include ':app'


### PR DESCRIPTION
## Summary
- set up Gradle files and app module
- add AndroidManifest, main layout, and MainActivity
- list desired features in the app's code
- update README with project overview

## Testing
- `gradle -v`
- `gradle tasks` *(fails: Directory does not contain a Gradle build)*

------
https://chatgpt.com/codex/tasks/task_e_6858761a3af883238cde6b0fa751ed38